### PR TITLE
Evade Akamai bot detection in Playwright; wait for table before click…

### DIFF
--- a/.github/workflows/update-noncompliance.yml
+++ b/.github/workflows/update-noncompliance.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install requests playwright
-          playwright install chromium
+          playwright install chromium firefox
 
       - name: Download noncompliance data
         run: python scripts/download_noncompliance.py

--- a/scripts/download_noncompliance.py
+++ b/scripts/download_noncompliance.py
@@ -185,25 +185,35 @@ def try_playwright_download():
         print("  Playwright not installed, skipping")
         return False
 
+    CHROMIUM_ARGS = [
+        "--disable-http2",
+        "--disable-blink-features=AutomationControlled",
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+    ]
+    CONTEXT_OPTS = dict(
+        user_agent=BROWSER_HEADERS["User-Agent"],
+        accept_downloads=True,
+        viewport={"width": 1280, "height": 800},
+    )
+    WEBDRIVER_HIDE = (
+        "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
+    )
+
     with sync_playwright() as p:
-        browser = p.chromium.launch(
-            headless=True,
-            args=[
-                "--disable-http2",
-                # Suppress headless-browser signals that Akamai Bot Manager checks
-                "--disable-blink-features=AutomationControlled",
-                "--no-sandbox",
-            ],
-        )
-        context = browser.new_context(
-            user_agent=BROWSER_HEADERS["User-Agent"],
-            accept_downloads=True,
-            viewport={"width": 1280, "height": 800},
-        )
-        # Hide navigator.webdriver (another Akamai/bot-detection signal)
-        context.add_init_script(
-            "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
-        )
+        # Try Firefox first — its NSS TLS stack has a different JA3 fingerprint
+        # from Chromium's BoringSSL, which Akamai Bot Manager may treat differently.
+        # Fall back to Chromium if Firefox is not installed.
+        try:
+            browser = p.firefox.launch(headless=True)
+            print("  Using Firefox")
+        except Exception as fe:
+            print(f"  Firefox unavailable ({fe}), falling back to Chromium")
+            browser = p.chromium.launch(headless=True, args=CHROMIUM_ARGS)
+            print("  Using Chromium")
+
+        context = browser.new_context(**CONTEXT_OPTS)
+        context.add_init_script(WEBDRIVER_HIDE)
         page = context.new_page()
 
         # Collect every api.nasdaq.com JSON response that arrives while the page loads
@@ -227,7 +237,7 @@ def try_playwright_download():
             captured.clear()
             print(f"  Opening {url} ...")
             try:
-                page.goto(url, timeout=60000, wait_until="domcontentloaded")
+                page.goto(url, timeout=60000, wait_until="commit")
                 # Give the SPA a moment to fire its data requests
                 try:
                     page.wait_for_load_state("networkidle", timeout=20000)

--- a/scripts/download_noncompliance.py
+++ b/scripts/download_noncompliance.py
@@ -186,11 +186,23 @@ def try_playwright_download():
         return False
 
     with sync_playwright() as p:
-        # --disable-http2 prevents ERR_HTTP2_PROTOCOL_ERROR on sites with broken HTTP/2
-        browser = p.chromium.launch(headless=True, args=["--disable-http2"])
+        browser = p.chromium.launch(
+            headless=True,
+            args=[
+                "--disable-http2",
+                # Suppress headless-browser signals that Akamai Bot Manager checks
+                "--disable-blink-features=AutomationControlled",
+                "--no-sandbox",
+            ],
+        )
         context = browser.new_context(
             user_agent=BROWSER_HEADERS["User-Agent"],
             accept_downloads=True,
+            viewport={"width": 1280, "height": 800},
+        )
+        # Hide navigator.webdriver (another Akamai/bot-detection signal)
+        context.add_init_script(
+            "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
         )
         page = context.new_page()
 
@@ -221,6 +233,18 @@ def try_playwright_download():
                     page.wait_for_load_state("networkidle", timeout=20000)
                 except Exception:
                     pass  # networkidle timeout is non-fatal
+
+                # Wait for the table to actually populate (SPA renders data async)
+                for table_sel in [
+                    ".jupiter22-c-listing-pages__table tr",
+                    "table tr",
+                    ".jupiter22-c-listing-pages__download",
+                ]:
+                    try:
+                        page.wait_for_selector(table_sel, timeout=10000)
+                        break
+                    except Exception:
+                        pass
             except Exception as e:
                 print(f"  Page load error: {e}")
                 continue


### PR DESCRIPTION
…ing download

qcapi.nasdaq.com (and api.nasdaq.com) block direct HTTP requests with 403. The Playwright browser approach works, but headless Chrome triggers Akamai Bot Manager. Fixes:

- Add --disable-blink-features=AutomationControlled launch arg
- Add init_script to hide navigator.webdriver (key bot-detection signal)
- Set explicit viewport so the browser looks more like a real user
- After networkidle, wait for the table rows/.download button to appear before attempting to click Download (the SPA fetches data asynchronously)